### PR TITLE
Fix: Allow Non-Annotated Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - Upgraded reflectable to `3.0.4`
 - Fixed:
     - Linter warnings
+    - Allow properties of classes extending `SmartArg` to not require an `Argument` annotation
 - Miscellaneous:
     - Upgraded dev_dependencies
         - test to `^1.18.2`

--- a/lib/src/smart_arg.dart
+++ b/lib/src/smart_arg.dart
@@ -62,22 +62,24 @@ class SmartArg {
             mirror.metadata.firstWhereOrNull((m) => m is Group) as Group? ??
                 currentGroup;
 
-        final parameter = mirror.metadata.firstWhere((m) => m is Argument);
-        final mpp = MirrorParameterPair(
-            mirror as VariableMirror, parameter as Argument, currentGroup);
-
-        for (final key in mpp.keys(_app)) {
-          if (_values.containsKey(key)) {
-            throw StateError('$key was configured multiple times');
+        final parameter =
+            mirror.metadata.firstWhereOrNull((m) => m is Argument);
+        if (parameter != null) {
+          final mpp = MirrorParameterPair(
+            mirror as VariableMirror,
+            parameter as Argument,
+            currentGroup,
+          );
+          for (final key in mpp.keys(_app)) {
+            if (_values.containsKey(key)) {
+              throw StateError('$key was configured multiple times');
+            }
+            _values[key] = mpp;
           }
-
-          _values[key] = mpp;
-        }
-
-        _mirrorParameterPairs.add(mpp);
-
-        if (parameter is Command) {
-          _commands[mpp.displayKey] = mpp;
+          _mirrorParameterPairs.add(mpp);
+          if (parameter is Command) {
+            _commands[mpp.displayKey] = mpp;
+          }
         }
       }
     }

--- a/test/smart_arg/smart_arg_test.dart
+++ b/test/smart_arg/smart_arg_test.dart
@@ -244,6 +244,17 @@ class TestWithDefaultValue extends SmartArg {
 }
 
 @SmartArg.reflectable
+@Parser(exitOnFailure: false)
+class TestWithNonAnnotationValue extends SmartArg {
+  @StringArgument()
+  String long = 'hello';
+
+  final String noAnnotation = 'Not Reflected';
+  String eagerProperty = 'Eager';
+  late String lateProperty = '$eagerProperty should be late';
+}
+
+@SmartArg.reflectable
 @Parser(exitOnFailure: false, extendedHelp: [ExtendedHelp(null)])
 class TestBadExtendedHelp extends SmartArg {}
 
@@ -340,6 +351,24 @@ void main() {
       test('value supplied overrides default value', () {
         final args = TestWithDefaultValue()..parse(['--long', 'goodbye']);
         expect(args.long, 'goodbye');
+      });
+    });
+
+    group('non-annotated values', () {
+      test('can exist within a command', () {
+        final args = TestWithNonAnnotationValue()..parse([]);
+        expect(args.long, 'hello');
+        expect(args.lateProperty, 'Eager should be late');
+        expect(args.noAnnotation, 'Not Reflected');
+      });
+
+      test('properties can be late for lazy evaluation', () {
+        final args = TestWithNonAnnotationValue()..parse([]);
+        expect(args.eagerProperty, 'Eager');
+        args.eagerProperty = 'Now Late';
+        expect(args.lateProperty, 'Now Late should be late');
+        args.eagerProperty = 'Back to Eager';
+        expect(args.lateProperty, 'Now Late should be late');
       });
     });
 


### PR DESCRIPTION
After: https://github.com/jcowgar/smart_arg/pull/22 _(I apparently can't change the base branch until it's merged in)_

Allows properties to exist on a class extending `SmartArg` that do not have annotations. (Previously errors were thrown).

These properties can also be late and lazily computed.

```
@SmartArg.reflectable
@Parser(exitOnFailure: false)
class TestWithNonAnnotationValue extends SmartArg {
  @StringArgument()
  String long = 'hello';

  final String noAnnotation = 'Not Reflected';
  String eagerProperty = 'Eager';
  late String lateProperty = '$eagerProperty should be late';
}
```